### PR TITLE
Do not show wrong chapter/volume number in UI

### DIFF
--- a/src/all/kavita/build.gradle
+++ b/src/all/kavita/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'Kavita'
     pkgNameSuffix = 'all.kavita'
     extClass = '.KavitaFactory'
-    extVersionCode = 14
+    extVersionCode = 15
 }
 
 dependencies {

--- a/src/all/kavita/src/eu/kanade/tachiyomi/extension/all/kavita/Kavita.kt
+++ b/src/all/kavita/src/eu/kanade/tachiyomi/extension/all/kavita/Kavita.kt
@@ -504,16 +504,8 @@ class Kavita(private val suffix: String = "") : ConfigurableSource, UnmeteredSou
             val allChapterList = mutableListOf<SChapter>()
             volumes.forEach { volume ->
                 run {
-                    if (volume.number == 0) {
-                        // Regular chapters
-                        volume.chapters.map {
-                            allChapterList.add(helper.chapterFromObject(it))
-                        }
-                    } else {
-                        // Volume chapter
-                        volume.chapters.map {
-                            allChapterList.add(helper.chapterFromVolume(it, volume))
-                        }
+                    volume.chapters.map {
+                        allChapterList.add(helper.chapterFromVolume(it, volume))
                     }
                 }
             }

--- a/src/all/kavita/src/eu/kanade/tachiyomi/extension/all/kavita/dto/MangaDto.kt
+++ b/src/all/kavita/src/eu/kanade/tachiyomi/extension/all/kavita/dto/MangaDto.kt
@@ -88,6 +88,29 @@ data class VolumeDto(
     val chapters: List<ChapterDto> = emptyList(),
 )
 
+enum class ChapterType {
+    Regular, // chapter with volume information
+    LooseLeaf, // chapter without volume information
+    SingleFileVolume,
+    Special,
+    ;
+
+    companion object {
+        fun of(chapter: ChapterDto, volume: VolumeDto): ChapterType =
+            if (volume.number == 100_000) {
+                Special
+            } else if (volume.number == -100_000) {
+                LooseLeaf
+            } else {
+                if (chapter.number == "-100000") {
+                    SingleFileVolume
+                } else {
+                    Regular
+                }
+            }
+    }
+}
+
 @Serializable
 data class ChapterDto(
     val id: Int,


### PR DESCRIPTION
Since the last update of kavita (v0.8.0) this extension shows wrong volume numbers to chapters without a volume number and shows wrong chapter number to volumes.

<details>
  <summary>See example</summary>
 
![Screenshot_20240413-120322](https://github.com/Kareadita/tach-extension/assets/28544097/b236a54e-0e8e-4430-9f27-aa12e8b6e77d)

</details>

I believe in the previous versions of kavita when a chapter or volume number did not exists Kavita used the number 0. now it is using -100000.

This MR changes how the extension checks if there is no volume/chapter information. Now I check if the number is less or equal than 0. This should keep the extension compatible with older versions of Kavita.

<details>
  <summary>Example with this MR</summary>
 
![Screenshot_20240413-122408](https://github.com/Kareadita/tach-extension/assets/28544097/a3c027a2-2ea5-4d76-8261-2db6ff7c2fa6)


</details>

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
