### PR TITLE
Fix library filter and remove filters from Popular tab

### DIFF
--- a/src/all/kavita/build.gradle
+++ b/src/all/kavita/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'Kavita'
     pkgNameSuffix = 'all.kavita'
     extClass = '.KavitaFactory'
-    extVersionCode = 14
+    extVersionCode = 15
 }
 
 dependencies {

--- a/src/all/kavita/src/eu/kanade/tachiyomi/extension/all/kavita/Kavita.kt
+++ b/src/all/kavita/src/eu/kanade/tachiyomi/extension/all/kavita/Kavita.kt
@@ -1184,7 +1184,7 @@ class Kavita(private val suffix: String = "") : ConfigurableSource, UnmeteredSou
                             }
                         }
                     // libraries
-                    client.newCall(GET("$apiUrl/Library", headersBuilder().build()))
+                    client.newCall(GET("$apiUrl/Library/libraries", headersBuilder().build()))
                         .execute().use { response ->
                             libraryListMeta = try {
                                 response.body.use { json.decodeFromString(it.string()) }


### PR DESCRIPTION
This PR fixes two problems:

1. The library filter was not working because the endpoint was wrong. 
2. The "Popular" tab uses the filters in the "filter" tab and sometime they can't be removed without restarting the app, steps to replicate:
   - Click the magnifying glass and search a manga by name
   - Click to the "Popular" tab. Now the popular tab will only show the mangas with the name matching the previous query and there is no way to remove this filter.

I did not update `extVersionCode` because there is also #1 pending and I wasn't sure to which number update it to. If you prefer I can move this changes into #1 so we have to update the extension only once. I created a new PR because you already started reviewing the code of the other PR and this PR tackles another issue.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
