### PR TITLE
Handle updates through merged chapters

### DIFF
--- a/src/all/kavita/build.gradle
+++ b/src/all/kavita/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'Kavita'
     pkgNameSuffix = 'all.kavita'
     extClass = '.KavitaFactory'
-    extVersionCode = 15
+    extVersionCode = 16
 }
 
 dependencies {

--- a/src/all/kavita/src/eu/kanade/tachiyomi/extension/all/kavita/Kavita.kt
+++ b/src/all/kavita/src/eu/kanade/tachiyomi/extension/all/kavita/Kavita.kt
@@ -513,11 +513,14 @@ class Kavita(private val suffix: String = "") : ConfigurableSource, UnmeteredSou
      * Fetches the "url" of each page from the chapter
      * **/
     override fun pageListRequest(chapter: SChapter): Request {
-        return GET("$apiUrl/${chapter.url}", headersBuilder().build())
+        // remove potential _<part> chapter salt
+        val chapterId = chapter.url.substringBefore("_")
+        return GET("$apiUrl/$chapterId", headersBuilder().build())
     }
 
     override fun fetchPageList(chapter: SChapter): Observable<List<Page>> {
-        val chapterId = chapter.url
+        // remove potential _<part> chapter salt
+        val chapterId = chapter.url.substringBefore("_")
         val numPages = chapter.scanlator?.replace(" pages", "")?.toInt()
         val numPages2 = "$numPages".toInt() - 1
         val pages = mutableListOf<Page>()

--- a/src/all/kavita/src/eu/kanade/tachiyomi/extension/all/kavita/KavitaHelper.kt
+++ b/src/all/kavita/src/eu/kanade/tachiyomi/extension/all/kavita/KavitaHelper.kt
@@ -98,6 +98,13 @@ class KavitaHelper {
             }
 
             url = chapter.id.toString()
+
+            if (chapter.fileCount > 1) {
+                // salt/offset to recognize chapters with new merged part-chapters as new and hence unread
+                chapter_number += 0.001f * chapter.fileCount
+                url = "${url}_${chapter.fileCount}"
+            }
+
             date_upload = parseDate(chapter.created)
             scanlator = "${chapter.pages} pages"
         }

--- a/src/all/kavita/src/eu/kanade/tachiyomi/extension/all/kavita/dto/MangaDto.kt
+++ b/src/all/kavita/src/eu/kanade/tachiyomi/extension/all/kavita/dto/MangaDto.kt
@@ -123,4 +123,13 @@ data class ChapterDto(
     val coverImageLocked: Boolean,
     val volumeId: Int,
     val created: String,
+    val files: List<FileDto>? = null,
+) {
+    val fileCount: Int
+        get() = files?.size ?: 0
+}
+
+@Serializable
+data class FileDto(
+    val id: Int,
 )


### PR DESCRIPTION
When a chapter gets new content server side through chapter merges, not only does the extension not notify the user of this update, but as long as the old data still resides in the cache, it’s straight up impossible to access the new chapter part.

This fix assumes  the only way a chapter would have multiple files is through part merges.
Unless multiple files are reported, nothing is changed, so this should be fairly backwards compatible too.

See also:
https://github.com/Kareadita/Kavita/issues/3272

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio