### PR TITLE
Fix pagination bug

### DIFF
--- a/src/all/kavita/src/eu/kanade/tachiyomi/extension/all/kavita/KavitaHelper.kt
+++ b/src/all/kavita/src/eu/kanade/tachiyomi/extension/all/kavita/KavitaHelper.kt
@@ -31,7 +31,7 @@ class KavitaHelper {
         var hasNextPage = false
         if (!paginationHeader.isNullOrEmpty()) {
             val paginationInfo = json.decodeFromString<PaginationInfo>(paginationHeader)
-            hasNextPage = paginationInfo.currentPage + 1 < paginationInfo.totalPages
+            hasNextPage = paginationInfo.currentPage < paginationInfo.totalPages
         }
         return hasNextPage
     }


### PR DESCRIPTION
Currently, the function that checks whether a next page is available is 0-based (`currentPage + 1 < totalPages`). However, since Kativa's pagination is 1-based, this results in the last page never being fetched.

See also report in #33.