### PR TITLE
Fix hard crash loop

### DIFF
--- a/src/all/kavita/build.gradle
+++ b/src/all/kavita/build.gradle
@@ -2,7 +2,7 @@ ext {
     kmkVersionCode = 1
     extName = 'Kavita'
     extClass = '.KavitaFactory'
-    extVersionCode = 21
+    extVersionCode = 22
     isNsfw = false
 }
 

--- a/src/all/kavita/src/eu/kanade/tachiyomi/extension/all/kavita/Kavita.kt
+++ b/src/all/kavita/src/eu/kanade/tachiyomi/extension/all/kavita/Kavita.kt
@@ -2587,10 +2587,8 @@ class Kavita(private val suffix: String = "") : ConfigurableSource, UnmeteredSou
                 try {
                     Log.d(LOG_TAG, "Starting Kavita extension initialization")
 
-                    // First attempt login with timeout
-                    val loginJob = async { doLogin() }
                     try {
-                        loginJob.await()
+                        doLogin()
                     } catch (e: Exception) {
                         Log.e(LOG_TAG, "Login failed during initialization", e)
                         initializationError = e


### PR DESCRIPTION
_It should be noted that this is a band-aid fix for deeper underlying issues._

The code as-was would attempt a login on every init, including when apps like Mihon would recover from the first crash by going to their global crash handler activity. This would loop several times until the OS intervened with a "[app] keeps crashing" sort of alert window.

This usually happened whenever a user would be unable to connect to their Kavita instance (server not up, different/no networks, etc) and left the user unable to fix the issue by removing the broken API URL or uninstalling the extension through the app's menus.

It doesn't matter if the Kavita instance that is unreachable is disabled in the extension settings, the crash will still occur because the login is performed in the `init` block, which is called regardless of an extension's specific enable/disable state (to be able to display settings, etc). This should probably be reworked in some way if feasible.

Fixes #48.

> [!IMPORTANT]
> I have bumped the `extVersionCode` up by one to 22, so the extension would now be on version `1.4.23`.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle`
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Have not changed source names
- [x] Have tested the modifications by compiling and running the extension through Android Studio
