### PR TITLE
Fix Kavita support for v0.9.1 (Version 1.4.23)

### DIFF
--- a/src/all/kavita/build.gradle
+++ b/src/all/kavita/build.gradle
@@ -2,7 +2,7 @@ ext {
     kmkVersionCode = 1
     extName = 'Kavita'
     extClass = '.KavitaFactory'
-    extVersionCode = 23
+    extVersionCode = 24
     isNsfw = false
 }
 

--- a/src/all/kavita/src/eu/kanade/tachiyomi/extension/all/kavita/dto/FilterDto.kt
+++ b/src/all/kavita/src/eu/kanade/tachiyomi/extension/all/kavita/dto/FilterDto.kt
@@ -48,10 +48,6 @@ data class FilterStatementDto(
 
 @Serializable
 data class SortOptions(
-    // Kavita validates SortField against the SeriesSortField enum (starts at 1); an
-    // omitted value deserializes to 0 and is rejected with HTTP 400. The host app
-    // serializes with encodeDefaults = false and this default equals the value
-    // popularMangaRequest sets, so force both fields to always be written.
     @EncodeDefault(EncodeDefault.Mode.ALWAYS)
     var sortField: Int = SortFieldEnum.AverageRating.type,
     @EncodeDefault(EncodeDefault.Mode.ALWAYS)

--- a/src/all/kavita/src/eu/kanade/tachiyomi/extension/all/kavita/dto/FilterDto.kt
+++ b/src/all/kavita/src/eu/kanade/tachiyomi/extension/all/kavita/dto/FilterDto.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.extension.all.kavita.dto
 
+import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.Serializable
 import kotlin.Triple
 
@@ -47,7 +48,13 @@ data class FilterStatementDto(
 
 @Serializable
 data class SortOptions(
+    // Kavita validates SortField against the SeriesSortField enum (starts at 1); an
+    // omitted value deserializes to 0 and is rejected with HTTP 400. The host app
+    // serializes with encodeDefaults = false and this default equals the value
+    // popularMangaRequest sets, so force both fields to always be written.
+    @EncodeDefault(EncodeDefault.Mode.ALWAYS)
     var sortField: Int = SortFieldEnum.AverageRating.type,
+    @EncodeDefault(EncodeDefault.Mode.ALWAYS)
     var isAscending: Boolean = true,
 )
 


### PR DESCRIPTION
Kavita 0.9.x validates the v2 filter's SortField against the SeriesSortField enum, which starts at 1. The host app serialises with encodeDefaults=false, and SortOptions.sortField's default value equalled the value popularMangaRequest sets, so kotlinx omitted it. The server read the missing enum as 0 and rejected the request with 'The field SortField is invalid', breaking the popular feed (and any query whose sort field matched the default).

Force SortOptions fields to always serialise via @EncodeDefault.

Closes #61

This has been done using ai, but i have reviewed the fix, build it and test it in a real device.

Checklist:

- [ x] Updated `extVersionCode` value in `build.gradle`
- [ x] Referenced all related issues in the PR body 
- [x ] Have not changed source names
- [x ] Have tested the modifications by compiling and running the extension through Android Studio
